### PR TITLE
feat: only staff can delete categories.

### DIFF
--- a/rareapi/views/categoryViewSet.py
+++ b/rareapi/views/categoryViewSet.py
@@ -24,7 +24,7 @@ class CategoryViewSet(ViewSet):
 
     def create(self, request):
         """
-            Handle POST requests for tags.
+            Handle POST requests for categories.
             Returns:
                 Response -- JSON serialized even instance.
         """
@@ -71,3 +71,26 @@ class CategoryViewSet(ViewSet):
             return Response(serialzied_categories.data)
         except Exception as ex:
             return HttpResponseServerError(ex)
+
+    def destroy(self, request, pk=None):
+        """
+            Handle DELETE request for a single category.
+            Returns:
+                Response - 200, 204, 500 status code.
+        """
+
+        try:
+            category = Category.objects.get(pk=pk)
+            user = request.auth.user
+            if user.is_staff:
+                category.delete()
+
+                return Response({}, status=status.HTTP_204_NO_CONTENT)
+
+            else:
+                return Response({'message': "Unauthorized"}, status=status.HTTP_401_UNAUTHORIZED)
+
+        except Category.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+        except Exception as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
# Description

Only logged-in user can delete categories.
Closes #16 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# Testing Instructions

`git fetch --all`
`git checkout cr-categories-delete`
`npm start`

For server-side code, see backend pull request.

If logged in as staff/admin, after logging in, click on `Category Management`.
Click any category to delete.
Page will rerender to show category deleted.

If logged in as non- staff/admin, after logging in, click on `Category Management`.
Delete option will not be available.


# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or errors
- [X] I have added test instructions that prove my fix is effective or that my feature works

	